### PR TITLE
Use precise zDepth measurement using user-defined tissue interface

### DIFF
--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -144,7 +144,7 @@ end
 zDepths = json.zDepths;
 
 %% Create dimensions structure for the entire tiled volume
-[dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(tiledScanInputFolder);
+[dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(tiledScanInputFolder, focusPositionInImageZpix);
 
 if cropZAroundFocusArea
     % Remove Z positions that are way out of focus (if we are doing focus processing)
@@ -199,7 +199,7 @@ parfor yI=1:length(dimOutput.y.values)
         
         % Relevant OCT tiles for this y, and what is the local y in the file
         [fps, yIInFile] = ...
-            yOCTProcessTiledScan_getScansFromYFrame(yI, tiledScanInputFolder);
+            yOCTProcessTiledScan_getScansFromYFrame(yI, tiledScanInputFolder, focusPositionInImageZpix);
         
         % Loop over all x stacks
         fileI = 1;

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -1,9 +1,14 @@
-function [dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(tiledScanInputFolder)
+function [dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(tiledScanInputFolder, focusPositionInImageZpix)
 % This is an auxilary function of yOCTProcessTiledScan designed to retun a
 % dim structure for both a single tile and the entier tiledScan
 
 %% Search and Load JSON file from  the tiledScanInputFolder
 json = awsReadJSON([tiledScanInputFolder 'ScanInfo.json']);
+
+%% Inform error if focusPositionInImageZpix is not provided
+if nargin < 2
+    error('focusPositionInImageZpix is required but was not passed to yOCTProcessTiledScan_createDimStructure.');
+end
 
 %% Pretend processing the first scan to get the dimension structure of one tile
 firstDataFolder = [tiledScanInputFolder json.octFolders{1}];
@@ -21,6 +26,7 @@ dimOneTile = yOCTChangeDimensionsStructureUnits(dimOneTile, 'mm');
 %% Update X&Y positions as they might not be reliable from scan
 
 % Dimensions of one tile
+dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(json.zDepths == 0));
 if ~isfield(json,'xRange_mm')
     % Backward compatibility
     warning('Note, that "%s" contains an old version scan, this will be depricated by Jan 1st, 2025',tiledScanInputFolder)
@@ -59,6 +65,7 @@ end
 xAll_mm = (min(xCenters_mm)+dimOneTile.x.values(1)):dx:(max(xCenters_mm)+dimOneTile.x.values(end)+dx/2);xAll_mm = xAll_mm(:);
 yAll_mm = (min(yCenters_mm)+dimOneTile.y.values(1)):dy:(max(yCenters_mm)+dimOneTile.y.values(end)+dy/2);yAll_mm = yAll_mm(:);
 zAll_mm = (min(zDepths_mm )+dimOneTile.z.values(1)):dz:(max(zDepths_mm) +dimOneTile.z.values(end)+dz/2);zAll_mm = zAll_mm(:);
+[~, zeroIndex] = min(abs(zAll_mm)); zAll_mm = dz * ((1:length(zAll_mm)) - zeroIndex); % Shift to set start origin exactly at 0
 
 % Correct for the case of only one scan
 if (length(xCenters_mm) == 1) %#ok<ISCL>
@@ -71,7 +78,7 @@ end
 %% Create dimensions data structure
 dimOutput.lambda = dimOneTile.lambda;
 dimOutput.z = dimOneTile.z; % Template, we will update it soon
-dimOutput.z.values = zAll_mm(:)' - zAll_mm(1);
+dimOutput.z.values = zAll_mm(:)';
 dimOutput.z.origin = 'z=0 is “user specified tissue interface”';
 dimOutput.x = dimOneTile.x;
 dimOutput.x.origin = 'x=0 is OCT scanner origin when xCenters=0 scan was taken';
@@ -82,5 +89,3 @@ dimOutput.y.values = yAll_mm(:)';
 dimOutput.y.index = 1:length(dimOutput.y.values);
 dimOutput.y.origin = 'y=0 is OCT scanner origin when yCenters=0 scan was taken';
 dimOutput.aux = dimOneTile.aux;
-
-

--- a/Processing/yOCTProcessTiledScan_getScansFromYFrame.m
+++ b/Processing/yOCTProcessTiledScan_getScansFromYFrame.m
@@ -1,6 +1,6 @@
 function [scanPaths, yIInFile] = ...
     yOCTProcessTiledScan_getScansFromYFrame(...
-    yFrameIndexInOutputVolume, tiledScanInputFolder)
+    yFrameIndexInOutputVolume, tiledScanInputFolder, focusPositionInImageZpix)
 % This is an auxilary function of yOCTProcessTiledScan designed to get a y
 % frame index in the overall tiled scan and return the exact tiles which
 % contain the data corresponding to that y frame.
@@ -15,7 +15,7 @@ function [scanPaths, yIInFile] = ...
 
 %% Load json and gather information
 json = awsReadJSON([tiledScanInputFolder 'ScanInfo.json']);
-[dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(tiledScanInputFolder);
+[dimOneTile, dimOutput] = yOCTProcessTiledScan_createDimStructure(tiledScanInputFolder, focusPositionInImageZpix);
 
 % Parse all scan paths
 scanPaths = cellfun(@(x)(awsModifyPathForCompetability([tiledScanInputFolder '\' x '\'])),json.octFolders,'UniformOutput',false);


### PR DESCRIPTION
Enhance z dimensions handling for focus positioning in reconstructed images and use a dedicated zero-depth index for easier referencing later