### PR TITLE
Add ImageJ/Fiji compatibility for Units Metadata display

### DIFF
--- a/LoadSave/yOCTFromTif.m
+++ b/LoadSave/yOCTFromTif.m
@@ -100,10 +100,12 @@ if (isInputFile)
     info = imfinfo(filepath);
 
     % Get meta data
-    if isfield(info(1),'ImageDescription')
-        description = info(1).ImageDescription;
-    else
-        description = '';
+    if isfield(info(1), 'Software') && strncmp(info(1).Software, '{', 1)
+        description = info(1).Software; % Use TIFF Tag "Software" so ImageJ/Fiji can read ImageDescription properly
+    elseif isfield(info(1), 'ImageDescription') && strncmp(info(1).ImageDescription, '{', 1)
+        description = info(1).ImageDescription;  % If 'Software' is not useful, check 'ImageDescription'
+    else    
+        description = '';  % No MetaData available
     end
     [c, metadata, maxbit] = intrpertDescription(description,filepath);
     


### PR DESCRIPTION
- Improve yOCT2Tif to embed unit information directly into TIFF tags, ensuring proper display in ImageJ.

- Store additional metadata in the Software tag to maintain compatibility and ensure full accessibility with yOCTFromTif readings.