### PR TITLE
Add ImageJ/Fiji compatibility for Units Metadata display

### DIFF
--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -178,20 +178,49 @@ if mode == 0
     % encode meta data
     metaJson = GenerateMetaData(metadata,c);
     
+    if isOutputFile
+        t = Tiff(outputFilePaths{1}, 'w');  % Open Tiff file
+    end
+
     for yI=1:size(data,3)
         bits = yOCT2Tif_ConvertBitsData(data(:,:,yI),c,false);
         
         % Save file
         if isOutputFile
-            if (yI==1)
-                imwrite(bits,outputFilePaths{1},...
-                    'Description',jsonencode(metaJson) ... Description contains min & max values
-                    );
-            else
-                imwrite(bits,outputFilePaths{1},...
-                    'writeMode','append');     
+            if yI > 1
+                t.writeDirectory();
             end
+
+            % Convert dimension structure to microns for accurate pixel spacing in ImageJ
+            meta_um = yOCTChangeDimensionsStructureUnits(metadata,'microns');
+            pixelSizeX_um = abs(meta_um.x.values(2) - meta_um.x.values(1));
+            pixelSizeZ_um = abs(meta_um.z.values(2) - meta_um.z.values(1));
+            
+            % Build and set TIFF tags. ImageJ uses 'XResolution', 'YResolution', 
+            % 'ResolutionUnit', and reads 'ImageDescription' (e.g., "unit=um") 
+            % to handle units and scaling display
+            tagstruct.ImageLength         = size(bits, 1);
+            tagstruct.ImageWidth          = size(bits, 2);
+            tagstruct.Photometric         = Tiff.Photometric.MinIsBlack;
+            tagstruct.BitsPerSample       = 16;                            
+            tagstruct.ResolutionUnit      = Tiff.ResolutionUnit.Centimeter; % Inch also possible
+            tagstruct.XResolution         = 1/(pixelSizeX_um*1e-4); % Resolution in microns
+            tagstruct.YResolution         = 1/(pixelSizeZ_um*1e-4); % Z is Y in ImageJ/Fiji
+            tagstruct.Compression         = Tiff.Compression.PackBits;
+            tagstruct.SamplesPerPixel     = 1;
+            tagstruct.RowsPerStrip        = size(bits, 1);
+            tagstruct.Orientation         = Tiff.Orientation.TopLeft;
+            tagstruct.ImageDescription    = sprintf('ImageJ=1.53\nunit=um\nspacing=1.00\nimages=%d\n', size(data,3));
+
+            % Store our yOCT metadata in the 'Software' tag as JSON. This field 
+            % is not parsed by ImageJ, and allows yOCTFromTif to safely retrieve 
+            % it later without interfering with standard image-reading Software
+            tagstruct.Software            = jsonencode(metaJson);  % Saves our metadata in the TIFF 'Software' Tag
+
+            t.setTag(tagstruct);
+            t.write(bits);
         end
+
         if isOutputFolder
             if (yI==1)
                 awsWriteJSON(metaJson, ...
@@ -200,6 +229,10 @@ if mode == 0
             p = yScanPath(outputFilePaths{2},yI);
             imwrite(bits,p);
         end
+    end
+
+    if isOutputFile
+        t.close();  % Close Tiff file
     end
     
     % At the end of the loop, upload to AWS if needed

--- a/Processing/yOCTFindTissueSurface.m
+++ b/Processing/yOCTFindTissueSurface.m
@@ -37,14 +37,22 @@ isVisualize = in.isVisualize;
 surface_depth = zeros(x_size, y_size);
 
 % Define Detection Parameters
-z_size_threshold = 800;    % Threshold to determine the starting depth based on image height
-high_z_start = 350;        % Starting depth for images with a large Z dimension
-low_z_start = 1;           % Starting pixel for images with a small Z dimension
 base_confirmations_required = 12;  % Initial consecutive pixels required to confirm surface
-intensity_threshold = 2;   % Threshold for pixel intensity to consider as potential surface
+percentile_threshold = 92;  % Threshold for pixel intensity to consider as potential surface
+z_size_threshold = 800;    % Threshold to determine the starting depth based on image height
+low_z_start = 1;           % Starting pixel for images with a small Z dimension
 
-% Adjust the start depth based on z_size
-if z_size > z_size_threshold
+% Starting depth for images with a large Z dimension
+z_column = logMeanAbs(:, floor(x_size/2), floor(y_size/2)); % vertical cross-section at the image midpoints
+vi = find(~isnan(z_column)); % Indices of valid (non-NaN) entries
+[~, ix] = sort(z_column(vi), 'descend', 'MissingPlacement','last'); % Sort descending and take top 20 to get tI
+tI = vi(ix(1:round(0.02 * z_size)));
+lz = min(tI); % Lowest (likely upper coverslip) of those top indices
+hz = max(tI); % Highest (likely down coverslip) of those top indices
+md = round((lz+hz)/2); % Midpoint to use
+% If coverslip thickness (hz−lz) is over 110, use md; otherwise use md - 60
+high_z_start = ((hz - lz) > 100) .* md + ((hz - lz) <= 100) .* (md - 60); 
+if z_size > z_size_threshold % Adjust the start depth based on z_size_threshold
     start_depth = high_z_start;
 else
     start_depth = low_z_start;
@@ -52,13 +60,18 @@ end
 
 % Main Loop - For each Y slice, analyze the data to find the surface height
 for y = 1:y_size
-    current_slice = logMeanAbs(:, :, y);
+    % Dynamically calculate the intensity_threshold
+    roi_data = logMeanAbs(:, max(1, floor(x_size/2) - 5):min(x_size, floor(x_size/2) + 5), y);
+    roi_data = roi_data(~isnan(roi_data)); % Region of interest (10 centered columns)
+    intensity_threshold = prctile(roi_data, percentile_threshold); % Intensity for specified percentile
+    
     surface_column = NaN(x_size, 1); % Initialize column for storing surface data
+    current_slice = logMeanAbs(:, :, y); % Current Y slice to be used for surface detection
 
     for x = 1:x_size % Iterate over each X position within the slice
         found = false;  % Initialize flag to track if surface is found
-        % Option to decrease confirmations needed if surface is not found
         
+        % Option to decrease confirmations needed if surface is not found
         for confirmations_required = base_confirmations_required:-1:11 % Adjustable decrease
             if found
                 break;  % Exit early if surface is found
@@ -68,7 +81,7 @@ for y = 1:y_size
                 if current_slice(z, x) >= intensity_threshold % Check if pixel intensity is above threshold
 
                     % Confirm surface if a sufficient number of consecutive pixels meet the criteria
-                    if (z + confirmations_required <= z_size) && all(current_slice(z+1:z+confirmations_required, x) > 0)
+                    if (z + confirmations_required <= z_size) && all(current_slice(z+1:z+confirmations_required, x) > (intensity_threshold - 2))
                         surface_column(x) = z;  % Record the surface depth
                         found = true;  % Update flag
                         break; % Stop scanning as surface is confirmed


### PR DESCRIPTION
- Improve yOCT2Tif to embed unit information directly into TIFF tags, ensuring proper display in ImageJ.

- Store additional metadata in the Software tag to maintain compatibility and ensure full accessibility with yOCTFromTif readings.

- Include extended explanatory comments in the sections.