### PR TITLE
Ensure always a zDepth = 0 scan

### DIFF
--- a/Demo_ScanAndProcess_3D.m
+++ b/Demo_ScanAndProcess_3D.m
@@ -9,7 +9,7 @@
 %% Inputs
 
 % Define the 3D Volume
-pixel_size_um = 1; % x-y Pixel size in microns
+pixel_size_um = 20; % x-y Pixel size in microns
 xOverall_mm = [-0.25 0.25]; % Define the overall volume you would like to scan [start, finish]. OBJECTIVE_DEPENDENT: For 10x use [-0.5 0.5], for 40x use [-0.25 0.25]
 yOverall_mm = [-0.25 0.25]; % Define the overall volume you would like to scan [start, finish]. OBJECTIVE_DEPENDENT: For 10x use [-0.5 0.5], for 40x use [-0.25 0.25]
 % Uncomment below to scan one B-Scan.

--- a/Demo_ScanAndProcess_3D.m
+++ b/Demo_ScanAndProcess_3D.m
@@ -22,7 +22,7 @@ oct2stageXYAngleDeg = 0; % Angle between x axis of the motor and the Galvo's x a
 
 % Define z stack and z-stitching
 scanZJump_um = 5; % microns. OBJECTIVE_DEPENDENT: For 10x use 15, for 40x use 5
-zToScan_mm = ([-100 (-30:scanZJump_um:400)])*1e-3; %[mm]
+zToScan_mm = unique([-100 (-30:scanZJump_um:400), 0])*1e-3; %[mm]
 focusSigma = 20; % When stitching along Z axis (multiple focus points), what is the size of each focus in z [pixels]. OBJECTIVE_DEPENDENT: for 10x use 20, for 40x use 20 or 1
 
 % Other scanning parameters

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -45,7 +45,11 @@ elseif length(focusPositionInImageZpix) == 1
     dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix);
 else
     % One value for each depth
-    dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(json.zDepths == 0));
+    if isempty(json.zDepths) || ~isnumeric(json.zDepths)
+        error('No correct zDepths scans found. Check your OCTVolume folder.');
+    end
+    [~, idx] = min(abs(json.zDepths));
+    dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(idx));
 end
 
 %% Compute pixel size


### PR DESCRIPTION
Focus is set at the coverslip tissue interface, defined as z = 0, our coordinate systems origin. This change ensures z=0 is always included in the scan.