### PR TITLE
Minor Improvements (see notes for details)

### DIFF
--- a/Demo_CheckFocusInTileScan.m
+++ b/Demo_CheckFocusInTileScan.m
@@ -5,20 +5,30 @@
 %% Inputs
 
 % Input folder
-tiledScanInputFolder = './'; % Make sure folder path ends with "/" to signal this is a folder
+sampleFolder = ''; % Input your main sample folder here. This folder should contain a folder called 'OCTVolume' with your OCT data. This is where your output file will be saved.
+tiledScanInputFolder = fullfile(sampleFolder, 'OCTVolume', filesep); % filesep should automatically set the appropriate file separator
 
 % Processing parameters
-dispersionQuadraticTerm=-2.059e8;
-focusSigma = 20; % When stitching along Z axis (multiple focus points), what is the size of each focus in z [pixels]. OBJECTIVE_DEPENDENT: for 10x use 20, for 40x use 20 or 1
+dispersionQuadraticTerm=-1.482e8;
+focusSigma = 6; % When stitching along Z axis (multiple focus points), what is the size of each focus in z [pixels]. OBJECTIVE_DEPENDENT: for 10x use 20, for 40x use 20 or 1
 applyPathLengthCorrection = true;
 
 % For all B-Scans, this parameter defines the depth (Z, pixels) that the focus is located at.
 % If set to NaN, yOCTFindFocusTilledScan will be executed to request user to select focus position.
 focusPositionInImageZpix = NaN;
 
-% Output
-numberOfZScansToOutput = 10; % Set to 1e5 to output all scans
-output_figure = 'out.tif';
+%% Output
+numberOfZScansToOutput = 2; % Set to 1e5 to output all scans
+
+% Extract only the last folder name from the sampleFolder path
+sampleName = regexp(sampleFolder, '[^\\/]+$', 'match', 'once');
+
+% Format the output figure name using the required inputs
+output_figure = sprintf('CheckFocusInTileScan__%s__dQ%.3e_fS%d_f%d.tif', ...
+    sampleName, dispersionQuadraticTerm, focusSigma, focusPositionInImageZpix);
+
+% Set the output path inside sampleFolder
+output_figure = fullfile(sampleFolder, output_figure);
 
 
 %% Preprocess

--- a/Demo_DispersionCorrectionManual.m
+++ b/Demo_DispersionCorrectionManual.m
@@ -5,8 +5,7 @@ close all;
 
 %% Inputs
 %Ganymede
-filePath = ['\\171.65.17.174\MATLAB_Share\Jenkins\myOCT Build\TestVectors\' ...
-    'Wasatch_3D'];
+filePath = [''];
 
 %% Pre-Process
 %Load Intef From file

--- a/Demo_PhotobleachSquare.m
+++ b/Demo_PhotobleachSquare.m
@@ -17,15 +17,62 @@ octProbePath = yOCTGetProbeIniPath('40x','OCTP900'); % Select lens magnification
 % Pattern to photobleach. System will photobleach n lines from 
 % (x_start(i), y_start(i)) to (x_end(i), y_end(i))
 scale = 0.25; % Length of each side of the square in mm
-bias = 0.01; % Use small bias [mm] to make sure lines are not too close to the edge of FOV
-x_start_mm = [-1, +1, +1, -1, -1.2, -1.2]*scale/2+bias;
-y_start_mm = [-1, -1, +1, +1, +1.2, +1.2]*scale/2+bias;
-x_end_mm   = [+1, +1, -1, -1, -1.2, +0  ]*scale/2+bias;
-y_end_mm   = [-1, +1, +1, -1, -1.2, +1.2]*scale/2+bias;
+bias = 0.0; % Use small bias [mm] to make sure lines are not too close to the edge of FOV
+photobleach_L_shape = true; % Select "true" if you want to photobleach an L shape outside of the square. Select "false" if not.
+photobleach_crosshairs = false; % Select "true" if you want to photobleach a crosshair pattern through the center of the square. Select "false" if not.
 
 % Photobleach configurations
 exposure_mm_sec = 20; % mm/sec
 nPasses = 1; % Keep as low as possible. If galvo gets stuck, increase number
+
+
+%% Initialize empty arrays
+x_start_mm = [];
+y_start_mm = [];
+x_end_mm   = [];
+y_end_mm   = [];
+
+
+%% Define patterns
+% Square (Base)
+square_x_start = [-1, +1, +1, -1]*scale/2 + bias;
+square_y_start = [-1, -1, +1, +1]*scale/2 + bias;
+square_x_end   = [+1, +1, -1, -1]*scale/2 + bias;
+square_y_end   = [-1, +1, +1, -1]*scale/2 + bias;
+
+% L-shape extension
+L_x_start = [-1.2, -1.2]*scale/2 + bias;
+L_y_start = [+1.2, +1.2]*scale/2 + bias;
+L_x_end   = [-1.2, +0  ]*scale/2 + bias;
+L_y_end   = [-1.2, +1.2]*scale/2 + bias;
+
+% Crosshairs
+cross_x_start = [0, 1]*scale/2 + bias;
+cross_y_start = [1, 0]*scale/2 + bias;
+cross_x_end   = [0, -1]*scale/2 + bias;
+cross_y_end   = [-1, 0]*scale/2 + bias;
+
+
+%% Combine patterns dynamically
+if photobleach_L_shape
+    x_start_mm = [x_start_mm, square_x_start, L_x_start];
+    y_start_mm = [y_start_mm, square_y_start, L_y_start];
+    x_end_mm   = [x_end_mm,   square_x_end,   L_x_end];
+    y_end_mm   = [y_end_mm,   square_y_end,   L_y_end];
+else
+    x_start_mm = [x_start_mm, square_x_start];
+    y_start_mm = [y_start_mm, square_y_start];
+    x_end_mm   = [x_end_mm,   square_x_end];
+    y_end_mm   = [y_end_mm,   square_y_end];
+end
+
+if photobleach_crosshairs
+    x_start_mm = [x_start_mm, cross_x_start];
+    y_start_mm = [y_start_mm, cross_y_start];
+    x_end_mm   = [x_end_mm,   cross_x_end];
+    y_end_mm   = [y_end_mm,   cross_y_end];
+end
+
 
 %% Photobleach
 yOCTPhotobleachTile(...

--- a/Demo_Process_3D.m
+++ b/Demo_Process_3D.m
@@ -4,9 +4,8 @@
 
 %% Iputs
 %Wasatch
-filePath = ['\\171.65.17.174\MATLAB_Share\Jenkins\myOCT Build\TestVectors\' ...
-    'Wasatch_3D\'];
-dispersionQuadraticTerm = 100; %Use Demo_DispersionCorrection to find the term
+filePath = [''];
+dispersionQuadraticTerm = -1.514e08; %Use Demo_DispersionCorrection to find the term
 
 yFramesPerBatch = 1; %How many Y frames to load in a single batch, optimzie this parameter to save computational time
 

--- a/Demo_ScanAndProcess_3D.m
+++ b/Demo_ScanAndProcess_3D.m
@@ -29,8 +29,9 @@ focusSigma = 20; % When stitching along Z axis (multiple focus points), what is 
 tissueRefractiveIndex = 1.4; % Use either 1.33 or 1.4 depending on the results. Use 1.4 for brain.
 % dispersionQuadraticTerm is OBJECTIVE_DEPENDENT
 %dispersionQuadraticTerm=6.539e07; % 10x
-%dispersionQuadraticTerm=9.56e7;   % 40x
-dispersionQuadraticTerm=-2.059e8;  % 10x, OCTP900
+%dispersionQuadraticTerm=9.56e07;   % 40x
+%dispersionQuadraticTerm=-2.059e08;  % 10x, OCTP900
+dispersionQuadraticTerm=-1.549e08;  % 40x, OCTP900
 
 % Where to save scan files
 output_folder = '\';


### PR DESCRIPTION
Demo_CheckFocusInTileScan:
1) Simplified input folder
2) Save output file with sample name and input parameters 3) Save output file to the input folder

Demo_DispersionCorrectionManual:
1) Removed old default filepath

Demo_PhotobleachSquare:
1) Remove default bias that caused shifting of photobleach square off-center 2) Added option to toggle L-shape
3) Added option to toggle crosshair pattern in center of square

Demo_Process_3D:
1) Removed old default file path
2) Updated default dispersionQuadraticTerm

Demo_ScanAndProcess_3D:
1) Standardized default dispersionQuadraticTerms
2) Added 40x, OCTP900 dispersionQuadraticTerm to default list