### PR TITLE
Enable BigTIFF saving to handle files >4GB

### DIFF
--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -179,7 +179,7 @@ if mode == 0
     metaJson = GenerateMetaData(metadata,c);
     
     if isOutputFile
-        t = Tiff(outputFilePaths{1}, 'w');  % Open Tiff file
+        t = Tiff(outputFilePaths{1}, 'w8');  % Open Tiff file as BigTIFF
     end
 
     for yI=1:size(data,3)


### PR DESCRIPTION
Use 'w8' to save TIFF as BigTIFF and prevent size limit errors (>4GB)