### PR TITLE
Fix z-depth validation & enforce zDepth=0 scan presence

### DIFF
--- a/Demo_ScanAndProcess_3D.m
+++ b/Demo_ScanAndProcess_3D.m
@@ -22,7 +22,7 @@ oct2stageXYAngleDeg = 0; % Angle between x axis of the motor and the Galvo's x a
 
 % Define z stack and z-stitching
 scanZJump_um = 5; % microns. OBJECTIVE_DEPENDENT: For 10x use 15, for 40x use 5
-zToScan_mm = ([-100 (-30:scanZJump_um:400)])*1e-3; %[mm]
+zToScan_mm = unique([-100 (-30:scanZJump_um:400), 0])*1e-3; %[mm]
 focusSigma = 10; % When stitching along Z axis (multiple focus points), what is the size of each focus in z [pixels]. OBJECTIVE_DEPENDENT: for 10x use 20, for 40x use 10 or 1
 
 % Other scanning parameters

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -46,7 +46,7 @@ elseif length(focusPositionInImageZpix) == 1
 else
     % One value for each depth
     if isempty(json.zDepths) || ~isnumeric(json.zDepths) % Validate presence of z-depths data
-        error('Missing or invalid zDepth scans found. Check JSON file or OCTVolume folder.');
+        error('ScanInfo.json reports zero scans (empty zDepths). This volume appears to be empty or failed.');
     end
     [~, idx] = min(abs(json.zDepths)); % Adjust z-dimensions using the focus index at zDepth 0
     dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(idx));

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -48,8 +48,14 @@ else
     if isempty(json.zDepths) || ~isnumeric(json.zDepths) % Validate presence of z-depths data
         error('ScanInfo.json reports zero scans (empty zDepths). This volume appears to be empty or failed.');
     end
-    [~, idx] = min(abs(json.zDepths)); % Adjust z-dimensions using the focus index at zDepth 0
-    dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(idx));
+    [~, idx] = min(abs(json.zDepths)); 
+    if abs(json.zDepths(idx)) > 0.01 % Validate that the z=0 reference (minimum zDepth) is within 10 microns (0.01 mm)
+        error('Invalid z=0 position: the closest zDepth is %.5f mm from zero. Expected a value less than 0.01 mm (10 microns).', json.zDepths(idx));
+    end
+    % Adjust z-dimensions using the focus index at zDepth 0
+    dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(idx)); 
+end
+
 end
 
 %% Compute pixel size

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -56,7 +56,6 @@ else
     dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(idx)); 
 end
 
-end
 
 %% Compute pixel size
 dx = diff(dimOneTile.x.values(1:2));

--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -37,15 +37,19 @@ end
 dimOneTile.x.values(end) = [];
 dimOneTile.y.values(end) = [];
 
-%% Correct dimOneTile.z to adjsut for focus position
+%% Correct dimOneTile.z to adjust for focus position
 if ~exist('focusPositionInImageZpix','var') || any(isnan(focusPositionInImageZpix))
-    % No adjustment
+    % No adjustment because no focus info is provided
 elseif length(focusPositionInImageZpix) == 1
-    % One value
+    % One single focus value; shift z-dimensions with this value
     dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix);
 else
     % One value for each depth
-    dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(json.zDepths == 0));
+    if isempty(json.zDepths) || ~isnumeric(json.zDepths) % Validate presence of z-depths data
+        error('Missing or invalid zDepth scans found. Check JSON file or OCTVolume folder.');
+    end
+    [~, idx] = min(abs(json.zDepths)); % Adjust z-dimensions using the focus index at zDepth 0
+    dimOneTile.z.values = dimOneTile.z.values - dimOneTile.z.values(focusPositionInImageZpix(idx));
 end
 
 %% Compute pixel size


### PR DESCRIPTION
- Guarantee at least one scan at zDepth=0 for consistent referencing.
- Add error message if zDepths is missing/invalid in JSON/OCTVolume.
- Adjust z-alignment using scan at zDepth=0 via index search.