### PR TITLE
Small refactor, see description

### DIFF
--- a/Applications/yOCTScanAndFindTissueSurface.m
+++ b/Applications/yOCTScanAndFindTissueSurface.m
@@ -7,7 +7,7 @@ function [surfacePosition_mm, x_mm, y_mm] = yOCTScanAndFindTissueSurface(varargi
 %       figure. Default is false
 %   octProbePath: Where is the probe.ini is saved to be used. Default 'probe.ini'.
 %   octProbeFOV_mm: How much of the field of view to use from the probe during scans.
-%   temporaryFolder: Directory for temporary files, default './temporary_files_folder'. 
+%   temporaryFolder: Directory for temporary files. 
 %       These files will be deleted after analysis is completed.
 %   dispersionQuadraticTerm: Dispersion compensation parameter.
 %   focusPositionInImageZpix: For all B-Scans, this parameter defines the 
@@ -33,7 +33,7 @@ addParameter(p,'yRange_mm',[-1 1]);
 addParameter(p,'pixel_size_um',25);
 addParameter(p,'octProbeFOV_mm',[]);
 addParameter(p,'octProbePath','probe.ini',@ischar);
-addParameter(p,'temporaryFolder','./Surface_Analysis_Temp/');
+addParameter(p,'temporaryFolder','./SurfaceAnalysisTemp/');
 addParameter(p,'dispersionQuadraticTerm',79430000,@isnumeric);
 addParameter(p,'focusPositionInImageZpix',NaN,@isnumeric);
 addParameter(p,'assertInFocusAcceptableRange_mm',0.025)

--- a/Applications/yOCTScanAndFindTissueSurface.m
+++ b/Applications/yOCTScanAndFindTissueSurface.m
@@ -7,7 +7,7 @@ function [surfacePosition_mm, x_mm, y_mm] = yOCTScanAndFindTissueSurface(varargi
 %       figure. Default is false
 %   octProbePath: Where is the probe.ini is saved to be used. Default 'probe.ini'.
 %   octProbeFOV_mm: How much of the field of view to use from the probe during scans.
-%   output_folder: Directory for temporary files, default './temporary_files_folder'. 
+%   temporaryFolder: Directory for temporary files, default './temporary_files_folder'. 
 %       These files will be deleted after analysis is completed.
 %   dispersionQuadraticTerm: Dispersion compensation parameter.
 %   focusPositionInImageZpix: For all B-Scans, this parameter defines the 
@@ -33,7 +33,7 @@ addParameter(p,'yRange_mm',[-1 1]);
 addParameter(p,'pixel_size_um',25);
 addParameter(p,'octProbeFOV_mm',[]);
 addParameter(p,'octProbePath','probe.ini',@ischar);
-addParameter(p,'output_folder','./Surface_Analysis_Temp/');
+addParameter(p,'temporaryFolder','./Surface_Analysis_Temp/');
 addParameter(p,'dispersionQuadraticTerm',79430000,@isnumeric);
 addParameter(p,'focusPositionInImageZpix',NaN,@isnumeric);
 addParameter(p,'assertInFocusAcceptableRange_mm',0.025)
@@ -50,7 +50,7 @@ isVisualize = in.isVisualize;
 octProbeFOV_mm = in.octProbeFOV_mm;
 octProbePath = in.octProbePath;
 dispersionQuadraticTerm = in.dispersionQuadraticTerm;
-output_folder = in.output_folder;
+temporaryFolder = in.temporaryFolder;
 v = in.v;
 
 if isnan(in.focusPositionInImageZpix)
@@ -60,7 +60,7 @@ focusPositionInImageZpix = in.focusPositionInImageZpix;
 
 %% Scan
 totalStartTime = datetime;  % Capture the starting time
-volumeOutputFolder = [output_folder '/OCTVolume/'];
+volumeOutputFolder = [temporaryFolder '/OCTVolume/'];
 if (v)
     fprintf('%s Scanning Volume...\n', datestr(datetime));
 end
@@ -86,7 +86,7 @@ end
 if (v)
     fprintf('%s Loading and processing the OCT scan...\n', datestr(datetime));
 end
-outputTiffFile = [output_folder '\surface_analysis.tiff'];
+outputTiffFile = [temporaryFolder '\surface_analysis.tiff'];
 yOCTProcessTiledScan(...
     volumeOutputFolder, ... Input
     {outputTiffFile},... Save only Tiff file as folder will be generated after smoothing
@@ -119,8 +119,8 @@ if (v)
 end
 
 %% Clean up
-if ~isempty(output_folder) && exist(output_folder, 'dir')
-    rmdir(output_folder, 's'); % Remove the output directory after processing
+if ~isempty(temporaryFolder) && exist(temporaryFolder, 'dir')
+    rmdir(temporaryFolder, 's'); % Remove the output directory after processing
 end
 totalEndTime = datetime;  % Capture the ending time
 totalDuration = totalEndTime - totalStartTime;

--- a/Applications/yOCTScanAndFindTissueSurface.m
+++ b/Applications/yOCTScanAndFindTissueSurface.m
@@ -2,7 +2,7 @@ function [surfacePosition_mm, x_mm, y_mm] = yOCTScanAndFindTissueSurface(varargi
 % This function uses the OCT to scan and then identify tissue surface from 
 % the OCT image.
 %   xRange_mm, yRange_mm: what range to scan, default [-1 1] mm.
-%   pixel_size_um: Pixel resolution for this analysis, default: 25 um.
+%   pixelSize_um: Pixel resolution for this analysis, default: 25 um.
 %   isVisualize: set to true to generate image heatmap visualization
 %       figure. Default is false
 %   octProbePath: Where is the probe.ini is saved to be used. Default 'probe.ini'.
@@ -30,7 +30,7 @@ p = inputParser;
 addParameter(p,'isVisualize',false);
 addParameter(p,'xRange_mm',[-1 1]);
 addParameter(p,'yRange_mm',[-1 1]);
-addParameter(p,'pixel_size_um',25);
+addParameter(p,'pixelSize_um',25);
 addParameter(p,'octProbeFOV_mm',[]);
 addParameter(p,'octProbePath','probe.ini',@ischar);
 addParameter(p,'temporaryFolder','./SurfaceAnalysisTemp/');
@@ -45,7 +45,7 @@ in = p.Results;
 
 xRange_mm = in.xRange_mm;
 yRange_mm = in.yRange_mm;
-pixel_size_um = in.pixel_size_um;
+pixelSize_um = in.pixelSize_um;
 isVisualize = in.isVisualize;
 octProbeFOV_mm = in.octProbeFOV_mm;
 octProbePath = in.octProbePath;
@@ -70,7 +70,7 @@ yOCTScanTile (...
     yRange_mm, ...
     'octProbeFOV_mm', octProbeFOV_mm, ...
     'octProbePath', octProbePath, ...
-    'pixelSize_um', pixel_size_um, ...
+    'pixelSize_um', pixelSize_um, ...
     'v',v,  ...
     'skipHardware', in.skipHardware ...
     );


### PR DESCRIPTION
1. If focusPositionInImageZpix is not provided, return an error. It's good engineering practice to not have user inputs inside a closed function. For this reason, if user didn't provide value, the function will fail.
2. Removing subfolders from output_folder
3. Removing user message " Please adjust the OCT focus such that it is precisely at the intersection of the tissue and the coverslip." because it's not true. The purpose of the function is to find the focus position, so we can't ask a user to provide it :)