### PR TITLE
Fix bug with slice‑spacing (y axis) metadata in ImageJ/Fiji

### DIFF
--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -211,12 +211,14 @@ if mode == 0
             % Check for valid metadata to set resolution accordingly in ImageJ
             if ~isempty(metadata) && ...
                 isfield(metadata, 'x') && isfield(metadata.x, 'values') && ...
+                isfield(metadata, 'y') && isfield(metadata.y, 'values') && ...
                 isfield(metadata, 'z') && isfield(metadata.z, 'values') && ...
-                numel(metadata.x.values) > 1 && numel(metadata.z.values) > 1
+                numel(metadata.x.values) > 1 && numel(metadata.y.values) > 1 && numel(metadata.z.values) > 1
 
                 % Convert dimension structure to microns for accurate pixel spacing in ImageJ
                 meta_um = yOCTChangeDimensionsStructureUnits(metadata,'microns');
                 pixelSizeX_um = abs(meta_um.x.values(2) - meta_um.x.values(1));
+                pixelSizeY_um = abs(meta_um.y.values(2) - meta_um.y.values(1));
                 pixelSizeZ_um = abs(meta_um.z.values(2) - meta_um.z.values(1));
 
                 % ImageJ uses 'XResolution', 'YResolution', 'ResolutionUnit', and reads 
@@ -224,10 +226,16 @@ if mode == 0
                 tagstruct.XResolution         = 1/(pixelSizeX_um*1e-4); % Resolution in microns
                 tagstruct.YResolution         = 1/(pixelSizeZ_um*1e-4); % Z is Y in ImageJ/Fiji
                 tagstruct.ResolutionUnit      = Tiff.ResolutionUnit.Centimeter; % Inch also possible
-                tagstruct.ImageDescription    = sprintf('ImageJ=1.53\nunit=um\nspacing=1.00\nimages=%d\n', size(data,3));
+                tagstruct.ImageDescription = sprintf( ...
+                    ['ImageJ=1.53\n' ...
+                     'unit=um\n' ...
+                     'spacing=%g\n' ...         % Spacing is Y axis (Z in Fiji)
+                     'images=%d\n'], ...
+                     pixelSizeY_um, size(data,3));
             else
+
                 % Default to 1 px if metadata is invalid or absent
-                warning('No valid metadata provided. Using default resolution = 1 pixel (no real-world scaling).');
+                % No valid metadata provided. Using default resolution = 1 pixel (no real-world scaling).
                 tagstruct.XResolution      = 1;   % 1 pixel
                 tagstruct.YResolution      = 1;   % 1 pixel
                 tagstruct.ResolutionUnit   = Tiff.ResolutionUnit.None; 

--- a/LoadSave/yOCT2Tif.m
+++ b/LoadSave/yOCT2Tif.m
@@ -209,6 +209,9 @@ if mode == 0
             tagstruct.Software            = jsonencode(metaJson);  % Saves our metadata in the TIFF 'Software' Tag
             
             % Check for valid metadata to set resolution accordingly in ImageJ
+            % Proceed only if metadata contains at least TWO samples in each axis (z, x, y).
+            % We need ≥2 points to compute pixel spacing => pixelSize = |v(2) – v(1)|.
+            % If any axis has ≤1 value we skip physical scaling and fall back to 1‑pixel units
             if ~isempty(metadata) && ...
                 isfield(metadata, 'x') && isfield(metadata.x, 'values') && ...
                 isfield(metadata, 'y') && isfield(metadata.y, 'values') && ...
@@ -229,7 +232,7 @@ if mode == 0
                 tagstruct.ImageDescription = sprintf( ...
                     ['ImageJ=1.53\n' ...
                      'unit=um\n' ...
-                     'spacing=%g\n' ...         % Spacing is Y axis (Z in Fiji)
+                     'spacing=%g\n' ...    % Set Z spacing in Fiji (which is the same as Y axis in metadata)
                      'images=%d\n'], ...
                      pixelSizeY_um, size(data,3));
             else
@@ -239,7 +242,7 @@ if mode == 0
                 tagstruct.XResolution      = 1;   % 1 pixel
                 tagstruct.YResolution      = 1;   % 1 pixel
                 tagstruct.ResolutionUnit   = Tiff.ResolutionUnit.None; 
-                tagstruct.ImageDescription = sprintf('ImageJ=1.53\nimages=%d\n', size(data,3));
+                tagstruct.ImageDescription = sprintf('ImageJ=1.53\nspacing=1.00\nimages=%d\n', size(data,3));
             end
 
             t.setTag(tagstruct);


### PR DESCRIPTION
Problem
-------

- Fiji had slices always show with 1.00 as spacing in the Y axis (Z in Fiji), regardless of the pixel_size. This made 3D views look wrong and not true to the actual scale when pixel size is different to 1um. For instance, an x, y = 6mm x 6mm image appeared as 0.6mm x 6mm if pixel_size was 10 um.

- Warning was spamming the console when dimensions were not provided.

What changed:

* Validates Y‑axis metadata and computes pixelSizeY_um.
* Adds `spacing=<pixelSizeY_um>` to the ImageJ header string (Z axis in Fiji/each slide).
* Removes the loop‑level warning that was spamming the console.

Result:

- Fiji now shows the correct voxel y axis (z in Fiji), appearing at true scale in 3‑D viewer and Properties.
- No Warning spamming the console if no dimensions provided.
- All tests passed.