### PR TITLE
fix length‑estimate bug in photobleach preview

### DIFF
--- a/ThorlabsImager/yOCTPhotobleachTile.m
+++ b/ThorlabsImager/yOCTPhotobleachTile.m
@@ -111,9 +111,10 @@ json.photobleachPlan = photobleachPlan;
 % Plot the plan
 if json.plotPattern
     % Estimate photobleach time
-    totalLineLength = sum(sum([photobleachPlan.lineLengths_mm{:}])); % mm
+    lenCells        = {photobleachPlan.lineLength_mm};   % Each cell is a vector
+    totalLineLength = sum([lenCells{:}]);                % Concatenate & sum
     estimatedPhotobleachTime_sec = totalLineLength*json.exposure; % sec
-   
+    
     yOCTPhotobleachTile_drawPlan(...
         photobleachPlan, json.FOV, estimatedPhotobleachTime_sec);
 end


### PR DESCRIPTION
What was wrong:

• We used the wrong field name: wrote lineLengths_mm (plural) but the struct is lineLength_mm (singular). Code crashed. &
• The total length line failed when only one tile was in the plan giving this error: 

_Intermediate dot '.' indexing produced a comma-separated list with 110 values, but it must produce a single value when followed by subsequent indexing operations._


What changed:

It tried to sum a comma‑separated list. Update flattens the cell array before summing, so it never crashes.

totalLineLength is now calculated with:

    lenCells        = {photobleachPlan.lineLength_mm};
    totalLineLength = sum([lenCells{:}]);

Now preview and time estimate run cleanly for both even and odd line sets