### PR TITLE
Add tests for uneven or tilted surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _private/*.*
 *.json
 *temp*
 
+*.gif


### PR DESCRIPTION
This pull request fixes a few issues
1. Adding test for the case where tissue surface is below the focus in addition to testing the case that tissue surface is above surface.
2. Dealing with the case that most of the tissue is in focus, but small part of it is out of focus.
3. Dealing with the case that large parts (but not all) of the surface cannot be estimated.
4. Dealing with the case of uneven tissue, where its impossible to put all of it in focus.