### PR TITLE
Correct mall bug with outputFilePixelSize_um

### DIFF
--- a/Processing/test_yOCTProcessTiledScan.m
+++ b/Processing/test_yOCTProcessTiledScan.m
@@ -1,0 +1,84 @@
+classdef test_yOCTProcessTiledScan < matlab.unittest.TestCase
+
+    properties
+
+    end
+    
+    methods(Test)
+        function testLoadSaveNoStitchingNoFocus(testCase)
+            % Confirm that yOCTProcessTiledScan works when:
+            %   outputFilePixelSize_um = [] -> keeps native spacing
+            %   outputFilePixelSize_um omitted (default 1 micron isotropic)
+            %   And that the Z-dimension length scales as expected.
+
+            % Generate Data
+            dummyData = zeros(1000,500,2)+1;
+            pixelSize_um = 1; 
+            outputFolder = 'tmp/';
+            octProbePath = yOCTGetProbeIniPath('40x','OCTP900');
+            focusPositionInImageZpix = 1;
+            focusSigma = 1000;
+            dummyData([100, 200, 300],:,:) = 100;
+
+            % Generate simulated data
+            json = yOCTSimulateTileScan(dummyData,outputFolder,...
+                        'pixelSize_um', pixelSize_um, ...
+                        'zDepths',      0, ...
+                        'focusPositionInImageZpix', focusPositionInImageZpix,... % No Z scan filtering
+                        'focusSigma',focusSigma, ...
+                        'octProbePath', octProbePath ...
+                        );
+
+            % Process with [] (Empty outputFilePixelSize_um)
+            yOCTProcessTiledScan(...
+                outputFolder, ... % Input
+                {'temp.tif'},...  % Output
+                'focusPositionInImageZpix', focusPositionInImageZpix,...
+                'focusSigma',focusSigma, ...
+                'dispersionQuadraticTerm',0, ...
+                'interpMethod','sinc5', ...
+                'cropZAroundFocusArea',false, ...
+                'outputFilePixelSize_um', []);
+            [data, dim] = yOCTFromTif('temp.tif');
+
+            % Process with the default (1 um - not passing anything)
+            yOCTProcessTiledScan(...
+                outputFolder, ... % Input (same simulated folder)
+                {'temp2.tif'},... % New output
+                'focusPositionInImageZpix', focusPositionInImageZpix,...
+                'focusSigma',focusSigma, ...
+                'dispersionQuadraticTerm',0, ...
+                'interpMethod','sinc5', ...
+                'cropZAroundFocusArea',false ... % outputFilePixelSize_um omitted: default 1 micron
+                );
+            [data2, dim2] = yOCTFromTif('temp2.tif');
+
+            % Validation
+            % Native pixel-size along Z (microns) used as reference
+            pixelSizeZ_native_um = mean(diff(dim.z.values))*1e3;
+
+            % Verify isotropic stack indeed has 1 micron per pixel in Z
+            pixelSizeZ_um = diff(dim2.z.values)*1e3; % in microns
+            testCase.verifyLessThan(max(abs(pixelSizeZ_um - 1)), 1e-3, ...
+                'dim2.z spacing is not 1 um per pixel');
+            
+            % Verify X and Y spacing are also 1 micron (full isotropy)
+            pixelSizeX_um = mean(diff(dim2.x.values))*1e3;
+            pixelSizeY_um = mean(diff(dim2.y.values))*1e3;
+            testCase.verifyLessThan(abs(pixelSizeX_um - 1), 1e-3, ...
+                'dim2.x spacing is not 1 um per pixel');
+            testCase.verifyLessThan(abs(pixelSizeY_um - 1), 1e-3, ...
+                'dim2.y spacing is not 1 um per pixel');
+
+            % Check total number of Z samples scales as expected
+            expectedLength = round(length(dim.z.values) * pixelSizeZ_native_um / 1);
+            testCase.verifyEqual(length(dim2.z.values), expectedLength, ...
+                'AbsTol',1, ...
+                'Z-dimension length after isotropic resampling is not as expected');
+
+            % Clean Up
+            rmdir(outputFolder, 's');
+            delete temp.tif temp2.tif;
+        end
+    end
+end

--- a/Processing/yOCTProcessTiledScan.m
+++ b/Processing/yOCTProcessTiledScan.m
@@ -65,7 +65,7 @@ addParameter(p,'v',true,@islogical);
 addParameter(p,'applyPathLengthCorrection',true); %TODO(yonatan) shift this parameter to ProcessScanFunction
 
 % Output file resolution
-addParameter(p,'outputFilePixelSize_um',1,@(x)(isnumeric(x) & x>0));
+addParameter(p,'outputFilePixelSize_um',1,@(x)(isempty(x) || (isnumeric(x) && isscalar(x) && x>0)));
 
 p.KeepUnmatched = true;
 if (~iscell(varargin{1}))
@@ -197,7 +197,7 @@ if ~isempty(in.outputFilePixelSize_um)
 
     % Change Z resolution
     dimOutput_mm.z.values = ...
-        (dimOutput_mm.z.values): ...
+        (dimOutput_mm.z.values(1)): ...
         (in.outputFilePixelSize_um*1e-3): ...
         max(dimOutput_mm.z.values);
     dimOutput_mm.z.index = 1:length(dimOutput_mm.z.values);


### PR DESCRIPTION
If we pass [] (empty) for outputFilePixelSize_um, the code currently crashes.

Instead, it should skip the isotropy check and keep whatever native step sizes came from the scan (XY could be 10 µm, Z = ~1.44 microns).

Now if we need (like yOCTScanAndFindTissueSurface currently does), we will pass [] to get the original inputs.

Also quick bug with newer MATLAB versions where in a vector, first value must be explicit (line 200).