### PR TITLE
Use update in yOCTScanTile rename

### DIFF
--- a/Processing/yOCTProcessTiledScan_createDimStructure.m
+++ b/Processing/yOCTProcessTiledScan_createDimStructure.m
@@ -40,8 +40,8 @@ if ~isfield(json,'xRange_mm')
     dimOneTile.x.values = json.xOffset+json.xRange*linspace(-0.5,0.5,json.nXPixels+1);
     dimOneTile.y.values = json.yOffset+json.yRange*linspace(-0.5,0.5,json.nYPixels+1);
 else
-    dimOneTile.x.values = json.xOffset+json.tileRangeX_mm*linspace(-0.5,0.5,json.nXPixels+1); 
-    dimOneTile.y.values = json.yOffset+json.tileRangeY_mm*linspace(-0.5,0.5,json.nYPixels+1);
+    dimOneTile.x.values = json.xOffset+json.tileRangeX_mm*linspace(-0.5,0.5,json.nXPixelsInEachTile+1); 
+    dimOneTile.y.values = json.yOffset+json.tileRangeY_mm*linspace(-0.5,0.5,json.nYPixelsInEachTile+1);
 end
 dimOneTile.x.values(end) = [];
 dimOneTile.y.values(end) = [];

--- a/ThorlabsImager/yOCTScanTile.m
+++ b/ThorlabsImager/yOCTScanTile.m
@@ -247,7 +247,7 @@ for attempt = 1:numRetries
             in.tileRangeX_mm * in.octProbe.DynamicFactorX, ... rangeX [mm]
             in.tileRangeY_mm,  ... rangeY [mm]
             0,       ... rotationAngle [deg]
-            in.nXPixels,in.nYPixels, ... SizeX,sizeY [# of pixels]
+            in.nXPixelsInEachTile,in.nYPixelsInEachTile, ... SizeX,sizeY [# of pixels per tile]
             in.nBScanAvg,       ... B Scan Average
             s ... Output directory, make sure this folder doesn't exist when starting the scan
             );


### PR DESCRIPTION
Previous update in yOCTScanTile renamed nPixels to nPixelsInEachTile

Here we add this new names in places where it was creating errors during scanning (in yOCTScanTile) and reconstruction (in yOCTProcessTiledScan_createDimStructure)