### PR TITLE
Fix FactorX for Y-axis stitching issue for 10x OCTP900 probe

### DIFF
--- a/ThorlabsImager/Probe - Olympus 10x - OCTP900.ini
+++ b/ThorlabsImager/Probe - Olympus 10x - OCTP900.ini
@@ -12,7 +12,7 @@ ObjectiveWorkingDistance = 3.5
 ## is at rest (slow axis), what position will it take based on the motor voltage?
 
 # Linear factor for x,y axis in volts/mm
-FactorX = -1.52607
+FactorX = 1.52607
 FactorY = -1.54077
 # Offset in volts
 OffsetX = -0.256806


### PR DESCRIPTION
Set FactorX positive in Olympus10xW OCTP900 to match physical Y direction and prevent row inversion during stitching with 10x.